### PR TITLE
Update to Go 1.21 to remove CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A pure Go MSSQL driver for Go's database/sql package
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/denisenkom/go-mssqldb.svg)](https://pkg.go.dev/github.com/denisenkom/go-mssqldb)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Melarian/go-mssqldb.svg)](https://pkg.go.dev/github.com/Melarian/go-mssqldb)
 [![Build status](https://ci.appveyor.com/api/projects/status/jrln8cs62wj9i0a2?svg=true)](https://ci.appveyor.com/project/denisenkom/go-mssqldb)
 [![codecov](https://codecov.io/gh/denisenkom/go-mssqldb/branch/master/graph/badge.svg)](https://codecov.io/gh/denisenkom/go-mssqldb)
 
@@ -10,7 +10,7 @@ For more recent updates, see the [Microsoft fork](https://github.com/microsoft/g
 
 Requires Go 1.8 or above.
 
-Install with `go get github.com/denisenkom/go-mssqldb` .
+Install with `go get github.com/Melarian/go-mssqldb` .
 
 ## Connection Parameters and DSN
 
@@ -142,7 +142,7 @@ import (
   "net/url"
 
   // Import the Azure AD driver module (also imports the regular driver package)
-  "github.com/denisenkom/go-mssqldb/azuread"
+  "github.com/Melarian/go-mssqldb/azuread"
 )
 
 func ConnectWithMSI() (*sql.DB, error) {
@@ -290,9 +290,9 @@ are supported:
  or add a `select ID = convert(bigint, SCOPE_IDENTITY());` to the end of your
  query (ref [SCOPE_IDENTITY](https://docs.microsoft.com/en-us/sql/t-sql/functions/scope-identity-transact-sql)).
  This will ensure you are getting the correct ID and will prevent a network round trip.
-* [NewConnector](https://godoc.org/github.com/denisenkom/go-mssqldb#NewConnector)
+* [NewConnector](https://godoc.org/github.com/Melarian/go-mssqldb#NewConnector)
     may be used with [OpenDB](https://golang.org/pkg/database/sql/#OpenDB).
-* [Connector.SessionInitSQL](https://godoc.org/github.com/denisenkom/go-mssqldb#Connector.SessionInitSQL)
+* [Connector.SessionInitSQL](https://godoc.org/github.com/Melarian/go-mssqldb#Connector.SessionInitSQL)
  may be set to set any driver specific session settings after the session
  has been reset. If empty the session will still be reset but use the database
  defaults in Go1.10+.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ version: 1.0.{build}
 image:
   - Visual Studio 2015
 
-clone_folder: c:\gopath\src\github.com\denisenkom\go-mssqldb
+clone_folder: c:\gopath\src\github.com\Melarian\go-mssqldb
 
 environment:
   GOPATH: c:\gopath

--- a/azuread/azuread_test.go
+++ b/azuread/azuread_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 func TestAzureSqlAuth(t *testing.T) {

--- a/azuread/configuration_test.go
+++ b/azuread/configuration_test.go
@@ -3,8 +3,8 @@ package azuread
 import (
 	"testing"
 
-	mssql "github.com/denisenkom/go-mssqldb"
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	mssql "github.com/Melarian/go-mssqldb"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 func TestValidateParameters(t *testing.T) {
@@ -96,7 +96,7 @@ func TestValidateParameters(t *testing.T) {
 				password:        accessToken,
 				adalWorkflow:    mssql.FedAuthADALWorkflowNone,
 				fedAuthWorkflow: ActiveDirectoryServicePrincipalAccessToken,
-				fedAuthLibrary: mssql.FedAuthLibrarySecurityToken,
+				fedAuthLibrary:  mssql.FedAuthLibrarySecurityToken,
 			},
 		},
 	}

--- a/azuread/driver.go
+++ b/azuread/driver.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 // DriverName is the name used to register the driver

--- a/bulkcopy.go
+++ b/bulkcopy.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denisenkom/go-mssqldb/internal/decimal"
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/internal/decimal"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 type Bulk struct {

--- a/bulkimport_example_test.go
+++ b/bulkimport_example_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 const (

--- a/datetimeoffset_example_test.go
+++ b/datetimeoffset_example_test.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"time"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 	"github.com/golang-sql/civil"
 )
 

--- a/doc/how-to-perform-bulk-imports.md
+++ b/doc/how-to-perform-bulk-imports.md
@@ -5,7 +5,7 @@ To use the bulk imports feature in go-mssqldb, you need to import the sql and go
 ```
 import (
     "database/sql"
-    "github.com/denisenkom/go-mssqldb"
+    "github.com/Melarian/go-mssqldb"
 )
 ```
 

--- a/doc/how-to-use-newconnector.md
+++ b/doc/how-to-use-newconnector.md
@@ -7,7 +7,7 @@ To use the Connector type, first you need to import the sql and go-mssqldb packa
 ```
 import (
   "database/sql"
-  "github.com/denisenkom/go-mssqldb"
+  "github.com/Melarian/go-mssqldb"
 )
 ```
 

--- a/examples/azuread-accesstoken/managed_identity.go
+++ b/examples/azuread-accesstoken/managed_identity.go
@@ -7,7 +7,7 @@ import (
 	"log"
 
 	"github.com/Azure/go-autorest/autorest/adal"
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 var (

--- a/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
+++ b/examples/azuread-service-principal-authtoken/service_principal_authtoken.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/denisenkom/go-mssqldb"
-	"github.com/denisenkom/go-mssqldb/azuread"
+	_ "github.com/Melarian/go-mssqldb"
+	"github.com/Melarian/go-mssqldb/azuread"
 )
 
 var (

--- a/examples/bulk/bulk.go
+++ b/examples/bulk/bulk.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/denisenkom/go-mssqldb"
+	"github.com/Melarian/go-mssqldb"
 )
 
 var (

--- a/examples/routine/routine.go
+++ b/examples/routine/routine.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"sync"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/Melarian/go-mssqldb"
 )
 
 var (

--- a/examples/simple/simple.go
+++ b/examples/simple/simple.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/Melarian/go-mssqldb"
 )
 
 var (

--- a/examples/tsql/tsql.go
+++ b/examples/tsql/tsql.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	_ "github.com/denisenkom/go-mssqldb"
+	_ "github.com/Melarian/go-mssqldb"
 )
 
 func main() {

--- a/examples/tvp/tvp.go
+++ b/examples/tvp/tvp.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	"github.com/denisenkom/go-mssqldb"
+	"github.com/Melarian/go-mssqldb"
 	"log"
 )
 

--- a/fedauth.go
+++ b/fedauth.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 // Federated authentication library affects the login data structure and message sequence.

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,29 @@
-module github.com/denisenkom/go-mssqldb
+module github.com/Melarian/go-mssqldb
 
-go 1.13
+go 1.21
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.19.0
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v0.11.0
-	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2
+	github.com/Azure/go-autorest/autorest/adal v0.9.23
+	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9
 	github.com/golang-sql/sqlexp v0.1.0
-	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
+	golang.org/x/crypto v0.22.0
+)
+
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
+	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
+	github.com/Azure/go-autorest/logger v0.2.1 // indirect
+	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 )

--- a/log.go
+++ b/log.go
@@ -3,7 +3,7 @@ package mssql
 import (
 	"context"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 const (

--- a/log_test.go
+++ b/log_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 // bufLogger implements the Logger interface for testing purposes.

--- a/messages_example_test.go
+++ b/messages_example_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"log"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 	"github.com/golang-sql/sqlexp"
 )
 

--- a/msdsn/conn_str.go
+++ b/msdsn/conn_str.go
@@ -80,7 +80,7 @@ func SetupTLS(certificate string, insecureSkipVerify bool, hostInCertificate str
 		ServerName:         hostInCertificate,
 		InsecureSkipVerify: insecureSkipVerify,
 
-		// fix for https://github.com/denisenkom/go-mssqldb/issues/166
+		// fix for https://github.com/Melarian/go-mssqldb/issues/166
 		// Go implementation of TLS payload size heuristic algorithm splits single TDS package to multiple TCP segments,
 		// while SQL Server seems to expect one TCP segment per encrypted TDS package.
 		// Setting DynamicRecordSizingDisabled to true disables that algorithm and uses 16384 bytes per TLS package

--- a/msdsn/conn_str_go115.go
+++ b/msdsn/conn_str_go115.go
@@ -10,7 +10,7 @@ import (
 )
 
 func setupTLSCommonName(config *tls.Config, pem []byte) error {
-	// fix for https://github.com/denisenkom/go-mssqldb/issues/704
+	// fix for https://github.com/Melarian/go-mssqldb/issues/704
 	// A SSL/TLS certificate Common Name (CN) containing the ":" character
 	// (which is a non-standard character) will cause normal verification to fail.
 	// Since the VerifyConnection callback runs after normal certificate

--- a/mssql.go
+++ b/mssql.go
@@ -15,16 +15,16 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/denisenkom/go-mssqldb/internal/querytext"
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/internal/querytext"
+	"github.com/Melarian/go-mssqldb/msdsn"
 	"github.com/golang-sql/sqlexp"
 )
 
 // ReturnStatus may be used to return the return value from a proc.
 //
-//   var rs mssql.ReturnStatus
-//   _, err := db.Exec("theproc", &rs)
-//   log.Printf("return status = %d", rs)
+//	var rs mssql.ReturnStatus
+//	_, err := db.Exec("theproc", &rs)
+//	log.Printf("return status = %d", rs)
 type ReturnStatus int32
 
 var driverInstance = &Driver{processQueryText: true}
@@ -861,12 +861,13 @@ func (r *Rows) ColumnTypeDatabaseTypeName(index int) string {
 // not a variable length type ok should return false.
 // If length is not limited other than system limits, it should return math.MaxInt64.
 // The following are examples of returned values for various types:
-//   TEXT          (math.MaxInt64, true)
-//   varchar(10)   (10, true)
-//   nvarchar(10)  (10, true)
-//   decimal       (0, false)
-//   int           (0, false)
-//   bytea(30)     (30, true)
+//
+//	TEXT          (math.MaxInt64, true)
+//	varchar(10)   (10, true)
+//	nvarchar(10)  (10, true)
+//	decimal       (0, false)
+//	int           (0, false)
+//	bytea(30)     (30, true)
 func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 	return makeGoLangTypeLength(r.cols[index].ti)
 }
@@ -874,9 +875,10 @@ func (r *Rows) ColumnTypeLength(index int) (int64, bool) {
 // It should return
 // the precision and scale for decimal types. If not applicable, ok should be false.
 // The following are examples of returned values for various types:
-//   decimal(38, 4)    (38, 4, true)
-//   int               (0, 0, false)
-//   decimal           (math.MaxInt64, math.MaxInt64, true)
+//
+//	decimal(38, 4)    (38, 4, true)
+//	int               (0, 0, false)
+//	decimal           (math.MaxInt64, math.MaxInt64, true)
 func (r *Rows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 	return makeGoLangTypePrecisionScale(r.cols[index].ti)
 }
@@ -1249,12 +1251,13 @@ func (r *Rowsq) ColumnTypeDatabaseTypeName(index int) string {
 // not a variable length type ok should return false.
 // If length is not limited other than system limits, it should return math.MaxInt64.
 // The following are examples of returned values for various types:
-//   TEXT          (math.MaxInt64, true)
-//   varchar(10)   (10, true)
-//   nvarchar(10)  (10, true)
-//   decimal       (0, false)
-//   int           (0, false)
-//   bytea(30)     (30, true)
+//
+//	TEXT          (math.MaxInt64, true)
+//	varchar(10)   (10, true)
+//	nvarchar(10)  (10, true)
+//	decimal       (0, false)
+//	int           (0, false)
+//	bytea(30)     (30, true)
 func (r *Rowsq) ColumnTypeLength(index int) (int64, bool) {
 	return makeGoLangTypeLength(r.cols[index].ti)
 }
@@ -1262,9 +1265,10 @@ func (r *Rowsq) ColumnTypeLength(index int) (int64, bool) {
 // It should return
 // the precision and scale for decimal types. If not applicable, ok should be false.
 // The following are examples of returned values for various types:
-//   decimal(38, 4)    (38, 4, true)
-//   int               (0, 0, false)
-//   decimal           (math.MaxInt64, math.MaxInt64, true)
+//
+//	decimal(38, 4)    (38, 4, true)
+//	int               (0, 0, false)
+//	decimal           (math.MaxInt64, math.MaxInt64, true)
 func (r *Rowsq) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 	return makeGoLangTypePrecisionScale(r.cols[index].ti)
 }

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 func TestBadOpen(t *testing.T) {

--- a/newconnector_example_test.go
+++ b/newconnector_example_test.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"strconv"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 var (

--- a/queries_go19_test.go
+++ b/queries_go19_test.go
@@ -559,7 +559,7 @@ END;
 // incorrect. Furthermore, the Data Race Detector would detect a data race because the output
 // variable is shared between the driver and the client application.
 //
-// Issue https://github.com/denisenkom/go-mssqldb/issues/378
+// Issue https://github.com/Melarian/go-mssqldb/issues/378
 func TestOutputParamWithRows(t *testing.T) {
 	sqltextcreate := `
 	CREATE PROCEDURE spwithoutputandrows
@@ -744,7 +744,7 @@ func TestParamNoName(t *testing.T) {
 // config may help with that, but wireshark wasn't decrypting TDS based TLS streams
 // even when using that.
 //
-// Issue https://github.com/denisenkom/go-mssqldb/issues/166
+// Issue https://github.com/Melarian/go-mssqldb/issues/166
 func TestTLSServerReadClose(t *testing.T) {
 	query := `
 with

--- a/queries_test.go
+++ b/queries_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 func driverWithProcess(t *testing.T, tl Logger) *Driver {
@@ -1031,7 +1031,7 @@ func TestStmt_SetQueryNotification(t *testing.T) {
 		rows.Close()
 	}
 	// notifications are sent to Service Broker
-	// see for more info: https://github.com/denisenkom/go-mssqldb/pull/90
+	// see for more info: https://github.com/Melarian/go-mssqldb/pull/90
 }
 
 func TestErrorInfo(t *testing.T) {

--- a/tds.go
+++ b/tds.go
@@ -16,7 +16,7 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 func parseInstances(msg []byte) map[string]map[string]string {
@@ -1142,7 +1142,7 @@ initiate_connection:
 			if config.DynamicRecordSizingDisabled == false {
 				config = config.Clone()
 
-				// fix for https://github.com/denisenkom/go-mssqldb/issues/166
+				// fix for https://github.com/Melarian/go-mssqldb/issues/166
 				// Go implementation of TLS payload size heuristic algorithm splits single TDS package to multiple TCP segments,
 				// while SQL Server seems to expect one TCP segment per encrypted TDS package.
 				// Setting DynamicRecordSizingDisabled to true disables that algorithm and uses 16384 bytes per TLS package

--- a/tds_login_test.go
+++ b/tds_login_test.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 type MockTransportDialer struct {

--- a/tds_test.go
+++ b/tds_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 )
 
 type MockTransport struct {
@@ -216,9 +216,12 @@ func testConnParams(t testing.TB) msdsn.Config {
 // TestConnParams returns a connection configuration based on environment variables or the contents of a text file
 // Set environment variable SQLSERVER_DSN to provide an entire connection string
 // Set environment variables HOST and DATABASE from which a minimal config will be created.
-//  If HOST and DATABASE are set, you can optionally set INSTANCE, SQLUSER, and SQLPASSWORD as well
+//
+//	If HOST and DATABASE are set, you can optionally set INSTANCE, SQLUSER, and SQLPASSWORD as well
+//
 // If environment variables are not set, it will look in the working directory for a file named .connstr
-//   If the file exists it will use the first line of the file as the file as the DSN
+//
+//	If the file exists it will use the first line of the file as the file as the DSN
 func GetConnParams() (*msdsn.Config, error) {
 	dsn := os.Getenv("SQLSERVER_DSN")
 	const logFlags = 127

--- a/token.go
+++ b/token.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	"github.com/denisenkom/go-mssqldb/msdsn"
+	"github.com/Melarian/go-mssqldb/msdsn"
 	"github.com/golang-sql/sqlexp"
 )
 

--- a/tvp_example_test.go
+++ b/tvp_example_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"log"
 
-	mssql "github.com/denisenkom/go-mssqldb"
+	mssql "github.com/Melarian/go-mssqldb"
 )
 
 // This example shows how to use tvp type

--- a/tvp_go19_db_test.go
+++ b/tvp_go19_db_test.go
@@ -1163,7 +1163,7 @@ func TestTVPObject(t *testing.T) {
 	}
 }
 
-// fix pointer uint in tvp https://github.com/denisenkom/go-mssqldb/issues/703
+// fix pointer uint in tvp https://github.com/Melarian/go-mssqldb/issues/703
 func TestTVPUnsigned(t *testing.T) {
 	checkConnStr(t)
 	tl := testLogger{t: t}

--- a/types.go
+++ b/types.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/denisenkom/go-mssqldb/internal/cp"
-	"github.com/denisenkom/go-mssqldb/internal/decimal"
+	"github.com/Melarian/go-mssqldb/internal/cp"
+	"github.com/Melarian/go-mssqldb/internal/decimal"
 )
 
 // fixed-length data types


### PR DESCRIPTION
Mainly updated to Go v 1.21 as well as updating dependencies. There were CSVs that needed to be addressed. Left some TODOs in the azuread\configuration.go that will need to be addressed by someone who knows Azure.